### PR TITLE
追加したhandlerが動くようにする！

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-bot: bundle exec ruboty
+bot: bundle exec ruboty --load loader.rb
 

--- a/loader.rb
+++ b/loader.rb
@@ -1,0 +1,1 @@
+Dir[File.expand_path("../lib/**/*.rb", __FILE__)].each { |f| require f }


### PR DESCRIPTION
lib/ruboty/handlers以下のhanlderをプラグインより先にロードするようにする
Fix #4