### PR TITLE
slack用のgemをproduction用にくくる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source "https://rubygems.org"
 
 gem "dotenv"
 gem "ruboty"
-gem "ruboty-slack_rtm"
-gem "ruboty-snack"
 gem "ruboty-talk"
 
+group :production do
+  gem "ruboty-slack_rtm"
+  gem "ruboty-snack"
+end


### PR DESCRIPTION
herokuにdeployしたときだけslack用のgem使うようにする